### PR TITLE
Fix dockerfile and add a test-run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get -y update && \
     apt-get -y upgrade && \
-    apt-get install -y guile-2.2 guile-json qpdf poppler-utils
+    apt-get install -y guile-json qpdf poppler-utils
 
 RUN mkdir -p /opt/addon
 COPY src/addon.scm /opt/addon/

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+project_dir=$(git rev-parse --show-toplevel)
+
+docker run \
+       --mount type=bind,source="$project_dir/test",target=/mnt \
+       --env ITEM_DATA_JSON=/mnt/item_data.json \
+       --env OUTPUT_DIR=/mnt/tmp \
+       --env ITEM_PDF_DIR=/mnt/pdf \
+       rotate-pdf-addon \
+       /mnt/input.json


### PR DESCRIPTION
Debian removed the `guile-2.2` package. It now relies on installing the right guile version as a dependency to `guile-json`.